### PR TITLE
Add optional variable asg_wait_for_elb_capacity

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -27,7 +27,7 @@ module "autoscaling-deployment" {
 
   asg_health_check_grace_period = 30
   asg_health_check_type         = "EC2"
-  asg_wait_timeout              = "4m"
+  asg_wait_for_capacity_timeout = "4m"
   lc_security_groups            = []
   lc_instance_profile           = ""
   lc_instance_type              = "t2.medium"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+locals {
+  # Set the wait_for_elb_capacity to asg_min_capacity if not explicitly provided
+  asg_wait_for_elb_capacity = "${var.asg_wait_for_elb_capacity == -1 ? var.asg_min_capacity : var.asg_wait_for_elb_capacity}"
+}
+
 resource "random_id" "lc_name" {
   # This is so that the name will be changed if any of these changes
   keepers = {
@@ -89,7 +94,7 @@ resource "aws_autoscaling_group" "main" {
   metrics_granularity       = "${var.asg_metrics_granularity}"
   enabled_metrics           = "${var.asg_enabled_metrics}"
   wait_for_capacity_timeout = "${var.asg_wait_timeout}"
-  wait_for_elb_capacity     = "${var.asg_min_capacity}"
+  wait_for_elb_capacity     = "${local.asg_wait_for_elb_capacity}"
   service_linked_role_arn   = "${var.asg_service_linked_role_arn}"
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   # Set the wait_for_elb_capacity to asg_min_capacity if not explicitly provided
-  asg_wait_for_elb_capacity = "${var.asg_wait_for_elb_capacity == -1 ? var.asg_min_capacity : var.asg_wait_for_elb_capacity}"
+  asg_wait_for_elb_capacity = "${var.asg_wait_for_elb_capacity == "" ? var.asg_min_capacity : var.asg_wait_for_elb_capacity}"
 }
 
 resource "random_id" "lc_name" {
@@ -93,7 +93,7 @@ resource "aws_autoscaling_group" "main" {
   placement_group           = "${var.asg_placement_group}"
   metrics_granularity       = "${var.asg_metrics_granularity}"
   enabled_metrics           = "${var.asg_enabled_metrics}"
-  wait_for_capacity_timeout = "${var.asg_wait_timeout}"
+  wait_for_capacity_timeout = "${var.asg_wait_for_capacity_timeout}"
   wait_for_elb_capacity     = "${local.asg_wait_for_elb_capacity}"
   service_linked_role_arn   = "${var.asg_service_linked_role_arn}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,12 @@ variable "asg_tags" {
   description = "The created ASG (and spawned instances) will have these tags, merged over the default (see main.tf)"
 }
 
+variable "asg_wait_for_elb_capacity" {
+  type        = "string"
+  default     = -1
+  description = "Terraform will wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. If left to default, the value is set to asg_min_capacity"
+}
+
 variable "lc_security_groups" {
   type        = "list"
   description = "The spawned instances will have these security groups"

--- a/variables.tf
+++ b/variables.tf
@@ -52,11 +52,6 @@ variable "asg_max_capacity" {
   description = "The created ASG will have this number of instances at maximum"
 }
 
-variable "asg_wait_timeout" {
-  type        = "string"
-  description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out"
-}
-
 variable "asg_health_check_type" {
   type        = "string"
   default     = "ELB"
@@ -126,9 +121,14 @@ variable "asg_tags" {
   description = "The created ASG (and spawned instances) will have these tags, merged over the default (see main.tf)"
 }
 
+variable "asg_wait_for_capacity_timeout" {
+  type        = "string"
+  description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out"
+}
+
 variable "asg_wait_for_elb_capacity" {
   type        = "string"
-  default     = -1
+  default     = ""
   description = "Terraform will wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. If left to default, the value is set to asg_min_capacity"
 }
 


### PR DESCRIPTION
Set to asg_min_capacity if left to default

This is to prevent failure during creation even though the health check type is set to EC2