### PR TITLE
Add root block device arguments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,12 @@ resource "aws_launch_configuration" "main" {
   enable_monitoring    = "${var.lc_monitoring}"
   ebs_optimized        = "${var.lc_ebs_optimized}"
 
+  root_block_device = {
+    volume_size           = "${var.volume_size}"
+    volume_type           = "${var.volume_type}"
+    delete_on_termination = "${var.delete_on_termination}"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/variables.tf
+++ b/variables.tf
@@ -175,3 +175,20 @@ variable "lc_user_data" {
   default     = ""
   description = "The spawned instances will have this user data. Use the rendered value of a terraform's `template_cloudinit_config` data" // https://www.terraform.io/docs/providers/template/d/cloudinit_config.html#rendered
 }
+
+variable "volume_size" {
+  description = "The size of the volume in gigabytes"
+  type        = "string"
+  default     = "8"
+}
+
+variable "volume_type" {
+  description = "The type of volume. Can be standard, gp2, or io1"
+  type        = "string"
+  default     = "gp2"
+}
+
+variable "delete_on_termination" {
+  description = "Whether the volume should be destroyed on instance termination"
+  default     = "true"
+}


### PR DESCRIPTION
To create ASG instances are standardized like any other instances in shared account, we need to have `root_block_device` configuration in the module.