### PR TITLE
Fix Value of ManagedBy tag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,7 @@ resource "aws_autoscaling_group" "main" {
     },
     {
       key                 = "ManagedBy"
-      value               = "Terraform"
+      value               = "terraform"
       propagate_at_launch = true
     },
   ]


### PR DESCRIPTION
To follow resource tagging convention, which states we must use all lower case, then value of ManagedBy should be `terraform` in lower case.