### PR TITLE
upgrade aws naming provider for 0.12 readiness

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "random_lc" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.6.0"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.16.1"
 
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "launch_configuration"


### PR DESCRIPTION
The difference between v0.6.0 and v0.16.1 of terraform-aws-resource-naming:

1) it now supports many more resource types
2) validation bug fix
3) null and random providers have their versions upgraded

I am indirectly testing this change with the bastion module