### PR TITLE
Switch from EC2 Launch Configuration to EC2 Launch Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,19 @@ A terraform module which provisions an auto scaling group along with its launch 
 ## Conventions
  - the auto scaling group will have `Service`, `Cluster`, `Environment`, and `ProductDomain` tags by default, which are propagated to all instances it spawns
 
+## Migration from pre-launch-template versions
+1. upgrade to terraform v0.12+
+```bash
+terraform init
+terraform state rm module.<this module name in your terraform code>.module.random_lc
+terraform apply
+```
+
+
 ## Behaviour
-- Every time a new AMI is supplied (including first deployment), a new ASG will be created. If the deployment succeed, the old ASG will be destroyed.
-If the deployment failed because the ASG status is unhealthy, both the new and the old ASG will remain; if this new ASG is attached to an ALB target group, its instances should not receive traffic (as they are unhealthy). Subsequent failing deployments will add more unhealthy ASGs, and no ASG will be destroyed, but Terraform will state these ASGs as deposed. When a new healthy ASG is deployed, all old ASGs (the last healthy one and the subsequent unhealthy ones) will then be destroyed.
+- On the first deployment, this module will provision an ASG with a launch template that select the most recent AMI that passes through the given `image_filters`
+- Each time there's a change in the values of the `module.asg_name`'s keepers (e.g. security group, AMI ID), a new ASG will be provisioned by terraform, and the old one will later be destroyed (doing the "simple swap" deployment strategy).
+- When any launch template parameters' values are changed within the terraform code (e.g. a new image_filters is supplied), terraform will create a new launch template version, unless the new configuration is the same as the latest version of the launch template (e.g. when the launch template had been updated externally).
 
 ## Authors
   - [Salvian Reynaldi](https://github.com/salvianreynaldi)

--- a/data.tf
+++ b/data.tf
@@ -6,8 +6,8 @@ data "aws_ami" "latest_service_image" {
   dynamic "filter" {
     for_each = var.image_filters
     content {
-      name   = lookup(condition.value, "name", null)
-      values = lookup(condition.value, "values", null)
+      name   = lookup(filter.value, "name", null)
+      values = lookup(filter.value, "values", null)
     }
   }
 }

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,13 @@
+data "aws_ami" "latest_service_image" {
+  executable_users = ["self"]
+  owners           = var.image_owners
+  most_recent      = true
+
+  dynamic "filter" {
+    for_each = var.image_filters
+    content {
+      name   = lookup(condition.value, "name", null)
+      values = lookup(condition.value, "values", null)
+    }
+  }
+}

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -2,34 +2,33 @@ provider "aws" {
   region = "ap-southeast-1"
 }
 
-module "autoscaling-deployment" {
-  source                  = "../.."
-  service_name            = "fprbe"
-  environment             = "staging"
-  application             = "java-7"
-  product_domain          = "fprbe"
-  description             = "fprbe instances"
-  asg_min_capacity        = 2
-  asg_vpc_zone_identifier = ["subnet-8270c222"]
+module "asg" {
+  source = "../.."
 
-  asg_tags = [
+  service_name   = "fprbe"
+  environment    = "production"
+  product_domain = "fpr"
+  description    = "Instances of fprbe-app"
+  application    = "java-8"
+
+  security_groups  = []
+  instance_profile = "myinstance-profile"
+
+  image_owners = ["123456789012"]
+
+  image_filters = [
     {
-      key                 = "AmiId"
-      value               = "ami-9893cee4"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "ServiceVersion"
-      value               = "0.1.0"
-      propagate_at_launch = true
+      name   = "name"
+      values = ["traveloka-fprbe-app-*"]
     },
   ]
 
-  asg_health_check_grace_period = 30
-  asg_health_check_type         = "EC2"
-  asg_wait_for_capacity_timeout = "4m"
-  lc_security_groups            = []
-  lc_instance_profile           = ""
-  lc_instance_type              = "t2.medium"
-  lc_ami_id                     = "ami-9893cee4"
+  instance_type = "m5.large"
+  user_data     = "echo starting fprbe"
+  key_name      = ""
+
+  asg_vpc_zone_identifier  = ["subnet-a2b50c9d", "subnet-718c9efe"]
+  asg_lb_target_group_arns = []
+
+  asg_wait_for_capacity_timeout = "1m"
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -17,9 +17,15 @@ module "asg" {
   image_owners = ["123456789012"]
 
   image_filters = [
+    # See https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html for complete filter options
     {
       name   = "name"
       values = ["traveloka-fprbe-app-*"]
+    },
+    # If you want to directly specify the image ID
+    {
+      name   = "image-id"
+      values = ["ami-91920591023019"]
     },
   ]
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  # Set the wait_for_elb_capacity to asg_min_capacity if not explicitly provided
+  asg_wait_for_elb_capacity = "${var.asg_wait_for_elb_capacity == "" ? var.asg_min_capacity : var.asg_wait_for_elb_capacity}"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,100 +1,161 @@
-locals {
-  # Set the wait_for_elb_capacity to asg_min_capacity if not explicitly provided
-  asg_wait_for_elb_capacity = "${var.asg_wait_for_elb_capacity == "" ? var.asg_min_capacity : var.asg_wait_for_elb_capacity}"
-}
-
-module "random_lc" {
+module "launch_template_name" {
   source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.16.1"
 
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "launch_configuration"
+}
+module "asg_name" {
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.16.1"
 
+  name_prefix   = "${var.service_name}-${var.cluster_role}"
+  resource_type = "autoscaling_group"
   keepers = {
-    lc_security_groups  = "${join(",",sort(var.lc_security_groups))}"
-    lc_instance_profile = "${var.lc_instance_profile}"
-    lc_key_name         = "${var.lc_key_name}"
-    lc_instance_type    = "${var.lc_instance_type}"
-    lc_ami_id           = "${var.lc_ami_id}"
-    lc_monitoring       = "${var.lc_monitoring}"
-    lc_ebs_optimized    = "${var.lc_ebs_optimized}"
-    lc_user_data        = "${var.lc_user_data}"
+    image_id                  = "${data.aws_ami.latest_service_image.id}"
+    instance_profile          = "${var.instance_profile}"
+    key_name                  = "${var.key_name}"
+    security_groups           = "${join(",", sort(var.security_groups))}"
+    user_data                 = "${var.user_data}"
+    monitoring                = "${var.monitoring}"
+    ebs_optimized             = "${var.ebs_optimized}"
+    ebs_volume_size           = "${var.volume_size}"
+    ebs_volume_type           = "${var.volume_type}"
+    ebs_delete_on_termination = "${var.delete_on_termination}"
   }
 }
 
-resource "aws_launch_configuration" "main" {
-  name                 = "${module.random_lc.name}"
-  image_id             = "${var.lc_ami_id}"
-  instance_type        = "${var.lc_instance_type}"
-  iam_instance_profile = "${var.lc_instance_profile}"
-  key_name             = "${var.lc_key_name}"
-  security_groups      = ["${var.lc_security_groups}"]
-  user_data            = "${var.lc_user_data}"
-  enable_monitoring    = "${var.lc_monitoring}"
-  ebs_optimized        = "${var.lc_ebs_optimized}"
+resource "aws_launch_template" "main" {
+  name = "${module.launch_template_name.name}"
 
-  lifecycle {
-    create_before_destroy = true
+  image_id = "${data.aws_ami.latest_service_image.id}"
+
+  iam_instance_profile {
+    name = "${var.instance_profile}"
+  }
+
+  key_name               = "${var.key_name}"
+  vpc_security_group_ids = var.security_groups
+  user_data              = "${base64encode(var.user_data)}"
+
+  monitoring {
+    enabled = "${var.monitoring}"
+  }
+
+  ebs_optimized = "${var.ebs_optimized}"
+
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_size           = "${var.volume_size}"
+      volume_type           = "${var.volume_type}"
+      delete_on_termination = "${var.delete_on_termination}"
+    }
+  }
+
+  tags = {
+    Name          = "${module.launch_template_name.name}"
+    Service       = "${var.service_name}"
+    ProductDomain = "${var.product_domain}"
+    Environment   = "${var.environment}"
+    ManagedBy     = "terraform"
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = {
+      Name          = "${var.service_name}-${var.cluster_role}"
+      Service       = "${var.service_name}"
+      Cluster       = "${var.service_name}-${var.cluster_role}"
+      ProductDomain = "${var.product_domain}"
+      Application   = "${var.application}"
+      Environment   = "${var.environment}"
+      Description   = "${var.description}"
+      ManagedBy     = "terraform"
+    }
+  }
+  tag_specifications {
+    resource_type = "volume"
+
+    tags = {
+      Service       = "${var.service_name}"
+      ProductDomain = "${var.product_domain}"
+      Environment   = "${var.environment}"
+      ManagedBy     = "terraform"
+    }
   }
 }
 
 resource "aws_autoscaling_group" "main" {
-  name                      = "${aws_launch_configuration.main.name}"
+  name                      = "${module.asg_name.name}"
   max_size                  = "${var.asg_max_capacity}"
   min_size                  = "${var.asg_min_capacity}"
   default_cooldown          = "${var.asg_default_cooldown}"
-  launch_configuration      = "${aws_launch_configuration.main.name}"
   health_check_grace_period = "${var.asg_health_check_grace_period}"
   health_check_type         = "${var.asg_health_check_type}"
-  vpc_zone_identifier       = ["${var.asg_vpc_zone_identifier}"]
-  target_group_arns         = ["${var.asg_lb_target_group_arns}"]
-  termination_policies      = ["${var.asg_termination_policies}"]
+  vpc_zone_identifier       = var.asg_vpc_zone_identifier
+  target_group_arns         = var.asg_lb_target_group_arns
+  termination_policies      = var.asg_termination_policies
+
+  mixed_instances_policy {
+    launch_template {
+      launch_template_specification {
+        launch_template_id = "${aws_launch_template.main.id}"
+        version            = "$Latest"
+      }
+
+      dynamic "override" {
+        for_each = var.launch_template_overrides
+        content {
+          instance_type = lookup(override.value, "instance_type", null)
+        }
+      }
+    }
+
+    instances_distribution {
+      on_demand_allocation_strategy            = lookup(var.mixed_instances_distribution, "on_demand_allocation_strategy", null)
+      on_demand_base_capacity                  = lookup(var.mixed_instances_distribution, "on_demand_base_capacity", null)
+      on_demand_percentage_above_base_capacity = lookup(var.mixed_instances_distribution, "on_demand_percentage_above_base_capacity", null)
+      spot_allocation_strategy                 = lookup(var.mixed_instances_distribution, "spot_allocation_strategy", null)
+      spot_instance_pools                      = lookup(var.mixed_instances_distribution, "spot_instance_pools", null)
+      spot_max_price                           = lookup(var.mixed_instances_distribution, "spot_max_price", null)
+    }
+  }
 
   tags = [
     {
       key                 = "Name"
-      value               = "${aws_launch_configuration.main.name}"
-      propagate_at_launch = true
+      value               = "${module.asg_name.name}"
+      propagate_at_launch = false
     },
     {
       key                 = "Service"
       value               = "${var.service_name}"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "Cluster"
-      value               = "${var.service_name}-${var.cluster_role}"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "Environment"
-      value               = "${var.environment}"
-      propagate_at_launch = true
+      propagate_at_launch = false
     },
     {
       key                 = "ProductDomain"
       value               = "${var.product_domain}"
-      propagate_at_launch = true
+      propagate_at_launch = false
     },
     {
-      key                 = "Application"
-      value               = "${var.application}"
-      propagate_at_launch = true
+      key                 = "Environment"
+      value               = "${var.environment}"
+      propagate_at_launch = false
     },
     {
       key                 = "Description"
-      value               = "${var.description}"
-      propagate_at_launch = true
+      value               = "ASG of the ${var.service_name}-${var.cluster_role} cluster"
+      propagate_at_launch = false
     },
     {
       key                 = "ManagedBy"
-      value               = "Terraform"
-      propagate_at_launch = true
+      value               = "terraform"
+      propagate_at_launch = false
     },
   ]
 
-  tags = [
-    "${var.asg_tags}",
-  ]
+  tags = var.asg_tags
 
   placement_group           = "${var.asg_placement_group}"
   metrics_granularity       = "${var.asg_metrics_granularity}"
@@ -102,8 +163,4 @@ resource "aws_autoscaling_group" "main" {
   wait_for_capacity_timeout = "${var.asg_wait_for_capacity_timeout}"
   wait_for_elb_capacity     = "${local.asg_wait_for_elb_capacity}"
   service_linked_role_arn   = "${var.asg_service_linked_role_arn}"
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }

--- a/main.tf
+++ b/main.tf
@@ -161,4 +161,8 @@ resource "aws_autoscaling_group" "main" {
   wait_for_capacity_timeout = "${var.asg_wait_for_capacity_timeout}"
   wait_for_elb_capacity     = "${local.asg_wait_for_elb_capacity}"
   service_linked_role_arn   = "${var.asg_service_linked_role_arn}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -122,7 +122,7 @@ resource "aws_autoscaling_group" "main" {
     }
   }
 
-  tags = [
+  tags = concat([
     {
       key                 = "Name"
       value               = "${module.asg_name.name}"
@@ -153,9 +153,7 @@ resource "aws_autoscaling_group" "main" {
       value               = "terraform"
       propagate_at_launch = false
     },
-  ]
-
-  tags = var.asg_tags
+  ], var.asg_tags)
 
   placement_group           = "${var.asg_placement_group}"
   metrics_granularity       = "${var.asg_metrics_granularity}"

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "asg_lb_target_group_arns" {
 
 variable "asg_min_capacity" {
   type        = "string"
-  default     = 0
+  default     = "0"
   description = "The created ASG will have this number of instances at minimum"
 }
 
 variable "asg_max_capacity" {
   type        = "string"
-  default     = 0
+  default     = "0"
   description = "The created ASG will have this number of instances at maximum"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "asg_lb_target_group_arns" {
 
 variable "asg_min_capacity" {
   type        = "string"
-  default     = 1
+  default     = 0
   description = "The created ASG will have this number of instances at minimum"
 }
 
 variable "asg_max_capacity" {
   type        = "string"
-  default     = 5
+  default     = 0
   description = "The created ASG will have this number of instances at maximum"
 }
 
@@ -60,13 +60,13 @@ variable "asg_health_check_type" {
 
 variable "asg_health_check_grace_period" {
   type        = "string"
-  default     = 300
+  default     = "300"
   description = "Time, in seconds, to wait for new instances before checking their health"
 }
 
 variable "asg_default_cooldown" {
   type        = "string"
-  default     = 300
+  default     = "300"
   description = "Time, in seconds, the minimum interval of two scaling activities"
 }
 
@@ -118,7 +118,7 @@ variable "asg_termination_policies" {
 variable "asg_tags" {
   type        = "list"
   default     = []
-  description = "The created ASG (and spawned instances) will have these tags, merged over the default (see main.tf)"
+  description = "The created ASG will have these tags applied over the default ones (see main.tf)"
 }
 
 variable "asg_wait_for_capacity_timeout" {
@@ -132,46 +132,92 @@ variable "asg_wait_for_elb_capacity" {
   description = "Terraform will wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. If left to default, the value is set to asg_min_capacity"
 }
 
-variable "lc_security_groups" {
+variable "launch_template_overrides" {
+  type = list(map(string))
+
+  default = [
+    {
+      "instance_type" = "c5.large"
+    },
+    {
+      "instance_type" = "c4.large"
+    },
+  ]
+
+  description = "List of nested arguments provides the ability to specify multiple instance types. See https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#override"
+}
+
+variable "security_groups" {
   type        = "list"
   description = "The spawned instances will have these security groups"
 }
 
-variable "lc_instance_profile" {
+variable "instance_profile" {
   type        = "string"
   description = "The spawned instances will have this IAM profile"
 }
 
-variable "lc_key_name" {
+variable "key_name" {
   type        = "string"
   default     = ""
   description = "The spawned instances will have this SSH key name"
 }
 
-variable "lc_instance_type" {
-  type        = "string"
-  description = "The spawned instances will have this type"
+variable "image_filters" {
+  type        = "list"
+  description = "The AMI search filters. The most recent AMI that pass this filter will be deployed to the ASG"
 }
 
-variable "lc_ami_id" {
-  type        = "string"
-  description = "The spawned instances will have this AMI"
+variable "image_owners" {
+  type        = "list"
+  description = "List of AMI owners to limit search. This becomes required starting terraform-provider-aws v2 (https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#owners-argument-now-required)"
 }
 
-variable "lc_monitoring" {
+variable "monitoring" {
   type        = "string"
-  default     = true
+  default     = "true"
   description = "The spawned instances will have enhanced monitoring if enabled"
 }
 
-variable "lc_ebs_optimized" {
+variable "ebs_optimized" {
   type        = "string"
-  default     = false
+  default     = "false"
   description = "The spawned instances will have EBS optimization if enabled"
 }
 
-variable "lc_user_data" {
+variable "user_data" {
   type        = "string"
-  default     = ""
+  default     = " "
   description = "The spawned instances will have this user data. Use the rendered value of a terraform's `template_cloudinit_config` data" // https://www.terraform.io/docs/providers/template/d/cloudinit_config.html#rendered
+}
+
+variable "volume_size" {
+  description = "The size of the volume in gigabytes"
+  type        = "string"
+  default     = "8"
+}
+
+variable "volume_type" {
+  description = "The type of volume. Can be standard, gp2, or io1"
+  type        = "string"
+  default     = "gp2"
+}
+
+variable "delete_on_termination" {
+  description = "Whether the volume should be destroyed on instance termination"
+  default     = "true"
+}
+
+variable "mixed_instances_distribution" {
+  type        = "map"
+  description = "Specify the distribution of on-demand instances and spot instances. See https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstancesDistribution.html"
+
+  default = {
+    on_demand_allocation_strategy            = "prioritized"
+    on_demand_base_capacity                  = "0"
+    on_demand_percentage_above_base_capacity = "100"
+    spot_allocation_strategy                 = "lowest-price"
+    spot_instance_pools                      = "2"
+    spot_max_price                           = ""
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -165,7 +165,7 @@ variable "key_name" {
 
 variable "image_filters" {
   type        = "list"
-  description = "The AMI search filters. The most recent AMI that pass this filter will be deployed to the ASG"
+  description = "The AMI search filters. The most recent AMI that pass this filter will be deployed to the ASG. See https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html"
 }
 
 variable "image_owners" {


### PR DESCRIPTION
As launch configuration is deprecated, and some new EC2 features are only supported by launch template[1], I'm updating this module to use launch template

Some of launch template new features:
- Mixed instance policy: combine reserved, on-demand, and spot instances
- It's possible to set the order of preference of instance types that will be launched in the ASG
- Can tag launched instances + volumes, and the launch template itself
- Versionable
- Support new EC2 features: T3 unlimited burst, elastic gpu specification, and elastic inference accelerator

References
[1] https://docs.aws.amazon.com/autoscaling/ec2/userguide/create-asg.html