### PR TITLE
enable to set asg desired capacity

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -10,6 +10,7 @@ module "autoscaling-deployment" {
   product_domain          = "fprbe"
   description             = "fprbe instances"
   asg_min_capacity        = 2
+  asg_desired_capacity    = 1
   asg_vpc_zone_identifier = ["subnet-8270c222"]
 
   asg_tags = [
@@ -32,4 +33,5 @@ module "autoscaling-deployment" {
   lc_instance_profile           = ""
   lc_instance_type              = "t2.medium"
   lc_ami_id                     = "ami-9893cee4"
+  lc_user_data                  = " "
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   # Set the wait_for_elb_capacity to asg_min_capacity if not explicitly provided
   asg_wait_for_elb_capacity = "${var.asg_wait_for_elb_capacity == "" ? var.asg_min_capacity : var.asg_wait_for_elb_capacity}"
+  asg_desired_capacity      = "${var.asg_min_capacity > var.asg_desired_capacity ? var.asg_min_capacity : var.asg_desired_capacity}"
 }
 
 module "random_lc" {
@@ -41,6 +42,7 @@ resource "aws_autoscaling_group" "main" {
   name                      = "${aws_launch_configuration.main.name}"
   max_size                  = "${var.asg_max_capacity}"
   min_size                  = "${var.asg_min_capacity}"
+  desired_capacity          = "${local.asg_desired_capacity}"
   default_cooldown          = "${var.asg_default_cooldown}"
   launch_configuration      = "${aws_launch_configuration.main.name}"
   health_check_grace_period = "${var.asg_health_check_grace_period}"

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "asg_lb_target_group_arns" {
 
 variable "asg_min_capacity" {
   type        = "string"
-  default     = 1
+  default     = 0
   description = "The created ASG will have this number of instances at minimum"
 }
 
@@ -50,6 +50,12 @@ variable "asg_max_capacity" {
   type        = "string"
   default     = 5
   description = "The created ASG will have this number of instances at maximum"
+}
+
+variable "asg_desired_capacity" {
+  type        = "string"
+  default     = 1
+  description = "The created ASG will have this number of instances by default"
 }
 
 variable "asg_health_check_type" {


### PR DESCRIPTION
Enable to set ASG desired-capacity, just like deployment with ansible blue-green lc we now can set desired capacity (eg. wanna save some cost by setting the min to 0 and desired 1, with scaling policy to set it to 0 every midnight).