### PR TITLE
Switch from launch configuration to launch template

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A terraform module which provisions an auto scaling group along with its launch 
  - the auto scaling group will have `Service`, `Cluster`, `Environment`, and `ProductDomain` tags by default, which are propagated to all instances it spawns
 
 ## Behaviour
-- When the launch template parameter values are changed in the terraform code (e.g. a new image_filters is supplied), terraform will create a new launch template version, unless the new configuration is already the same as the latest version of the launch template (e.g. if the launch template is updated externally).
-- No rolling / blue green updates will be done automatically. It is assumed to be done externally
+- On the first deployment, this module will provision an ASG with a launch template that select the most recent AMI that passes through the given `image_filters`
+- No rolling / blue green updates will be done automatically. AMI deployment is assumed to be done externally
+- When any launch template parameters' values are changed within the terraform code (e.g. a new image_filters is supplied), terraform will create a new launch template version, unless the new configuration is the same as the latest version of the launch template (e.g. if the launch template had been updated externally during deployment).
 
 ## Authors
   - [Salvian Reynaldi](https://github.com/salvianreynaldi)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@ A terraform module which provisions an auto scaling group along with its launch 
 ## Conventions
  - the auto scaling group will have `Service`, `Cluster`, `Environment`, and `ProductDomain` tags by default, which are propagated to all instances it spawns
 
+## Migration from pre-launch-template versions
+```bash
+terraform init
+terraform state rm module.<this module name in your terraform code>.module.random_lc
+terraform apply
+```
+
+
 ## Behaviour
 - On the first deployment, this module will provision an ASG with a launch template that select the most recent AMI that passes through the given `image_filters`
-- No rolling / blue green updates will be done automatically. AMI deployment is assumed to be done externally
-- When any launch template parameters' values are changed within the terraform code (e.g. a new image_filters is supplied), terraform will create a new launch template version, unless the new configuration is the same as the latest version of the launch template (e.g. if the launch template had been updated externally during deployment).
+- Each time there's a change in the values of the `module.asg_name`'s keepers (e.g. security group, AMI ID), a new ASG will be provisioned by terraform, and the old one will later be destroyed (doing the "simple swap" deployment strategy).
+- When any launch template parameters' values are changed within the terraform code (e.g. a new image_filters is supplied), terraform will create a new launch template version, unless the new configuration is the same as the latest version of the launch template (e.g. when the launch template had been updated externally).
 
 ## Authors
   - [Salvian Reynaldi](https://github.com/salvianreynaldi)

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ terraform state rm module.<this module name in your terraform code>.module.rando
 terraform apply
 ```
 
-
 ## Behaviour
+- For on-demand instances, Auto Scaling will launch instances based on the order of preference specified in the `launch_template_overrides` list. [The default setting](variables.tf) specifies ["`c5.large`", "`c4.large`"] which means ASG will always try to launch `c5.large` if it's available, and `c4.large` otherwise
 - On the first deployment, this module will provision an ASG with a launch template that select the most recent AMI that passes through the given `image_filters`
 - Each time there's a change in the values of the `module.asg_name`'s keepers (e.g. security group, AMI ID), a new ASG will be provisioned by terraform, and the old one will later be destroyed (doing the "simple swap" deployment strategy).
-- When any launch template parameters' values are changed within the terraform code (e.g. a new image_filters is supplied), terraform will create a new launch template version, unless the new configuration is the same as the latest version of the launch template (e.g. when the launch template had been updated externally).
+- When there's a change in launch template parameters' values, terraform will create a new launch template version unless the new configuration is already the same as the latest version of the launch template (e.g. when the launch template had been updated externally).
 
 ## Authors
   - [Salvian Reynaldi](https://github.com/salvianreynaldi)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A terraform module which provisions an auto scaling group along with its launch 
  - the auto scaling group will have `Service`, `Cluster`, `Environment`, and `ProductDomain` tags by default, which are propagated to all instances it spawns
 
 ## Behaviour
-- Every time a new AMI is supplied (including first deployment), a new ASG will be created. If the deployment succeed, the old ASG will be destroyed.
-If the deployment failed because the ASG status is unhealthy, both the new and the old ASG will remain; if this new ASG is attached to an ALB target group, its instances should not receive traffic (as they are unhealthy). Subsequent failing deployments will add more unhealthy ASGs, and no ASG will be destroyed, but Terraform will state these ASGs as deposed. When a new healthy ASG is deployed, all old ASGs (the last healthy one and the subsequent unhealthy ones) will then be destroyed.
+- When the launch template parameter values are changed in the terraform code (e.g. a new image_filters is supplied), terraform will create a new launch template version, unless the new configuration is already the same as the latest version of the launch template (e.g. if the launch template is updated externally).
+- No rolling / blue green updates will be done automatically. It is assumed to be done externally
 
 ## Authors
   - [Salvian Reynaldi](https://github.com/salvianreynaldi)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ terraform apply
 ```
 
 ## Behaviour
-- For on-demand instances, Auto Scaling will launch instances based on the order of preference specified in the `launch_template_overrides` list. [The default setting](variables.tf) specifies ["`c5.large`", "`c4.large`"] which means ASG will always try to launch `c5.large` if it's available, and `c4.large` otherwise
+- To specify on-demand instance types, use the `launch_template_overrides` variable. Auto Scaling will launch instances based on the order of preference specified in that list. ["`c5.large`", "`c4.large`", "`m5.large`"] means the ASG will always try to launch `c5.large` if it's available, falling back to `c4.large` if it's not available, and falling back to `m5.large` if the previous two aren't available
 - On the first deployment, this module will provision an ASG with a launch template that select the most recent AMI that passes through the given `image_filters`
 - Each time there's a change in the values of the `module.asg_name`'s keepers (e.g. security group, AMI ID), a new ASG will be provisioned by terraform, and the old one will later be destroyed (doing the "simple swap" deployment strategy).
 - When there's a change in launch template parameters' values, terraform will create a new launch template version unless the new configuration is already the same as the latest version of the launch template (e.g. when the launch template had been updated externally).

--- a/data.tf
+++ b/data.tf
@@ -22,4 +22,6 @@ data "aws_ami" "latest_service_image" {
     name   = "tag:Status"
     values = ["${var.image_filter["tag_status"]}"]
   }
+
+  count = "${length(keys(var.image_filter)) == 0 ? 0 : 1}"
 }

--- a/data.tf
+++ b/data.tf
@@ -1,27 +1,16 @@
 data "aws_ami" "latest_service_image" {
   executable_users = ["self"]
   most_recent      = true
-  owners           = ["self"]
 
-  filter {
-    name   = "name"
-    values = ["${var.image_filter["name"]}"]
-  }
-
-  filter {
-    name   = "tag:Service"
-    values = ["${var.service_name}"]
-  }
-
-  filter {
-    name   = "tag:ProductDomain"
-    values = ["${var.product_domain}"]
-  }
-
-  filter {
-    name   = "tag:Status"
-    values = ["${var.image_filter["tag_status"]}"]
-  }
-
-  count = "${length(keys(var.image_filter)) == 0 ? 0 : 1}"
+  filter = [
+    {
+      name   = "tag:Service"
+      values = ["${var.service_name}"]
+    },
+    {
+      name   = "tag:ProductDomain"
+      values = ["${var.product_domain}"]
+    },
+    "${var.image_filters}",
+  ]
 }

--- a/data.tf
+++ b/data.tf
@@ -9,17 +9,17 @@ data "aws_ami" "latest_service_image" {
   }
 
   filter {
-    name   = "Tag:Service"
+    name   = "tag:Service"
     values = ["${var.service_name}"]
   }
 
   filter {
-    name   = "Tag:ProductDomain"
+    name   = "tag:ProductDomain"
     values = ["${var.product_domain}"]
   }
 
   filter {
-    name   = "Tag:Status"
+    name   = "tag:Status"
     values = ["${var.image_filter["tag_status"]}"]
   }
 }

--- a/data.tf
+++ b/data.tf
@@ -1,5 +1,6 @@
 data "aws_ami" "latest_service_image" {
   executable_users = ["self"]
+  owners           = ["${var.image_owners}"]
   most_recent      = true
 
   filter = [

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,25 @@
+data "aws_ami" "latest_service_image" {
+  executable_users = ["self"]
+  most_recent      = true
+  owners           = ["self"]
+
+  filter {
+    name   = "name"
+    values = ["${var.image_name_filter}"]
+  }
+
+  filter {
+    name   = "Tag:Service"
+    values = ["${var.service_name}"]
+  }
+
+  filter {
+    name   = "Tag:ProductDomain"
+    values = ["${var.product_domain}"]
+  }
+
+  filter {
+    name   = "Tag:Status"
+    values = ["${var.image_status}"]
+  }
+}

--- a/data.tf
+++ b/data.tf
@@ -4,14 +4,6 @@ data "aws_ami" "latest_service_image" {
   most_recent      = true
 
   filter = [
-    {
-      name   = "tag:Service"
-      values = ["${var.service_name}"]
-    },
-    {
-      name   = "tag:ProductDomain"
-      values = ["${var.product_domain}"]
-    },
     "${var.image_filters}",
   ]
 }

--- a/data.tf
+++ b/data.tf
@@ -5,7 +5,7 @@ data "aws_ami" "latest_service_image" {
 
   filter {
     name   = "name"
-    values = ["${var.image_filter.name}"]
+    values = ["${var.image_filter["name"]}"]
   }
 
   filter {
@@ -20,6 +20,6 @@ data "aws_ami" "latest_service_image" {
 
   filter {
     name   = "Tag:Status"
-    values = ["${var.image_filter.tag_status}"]
+    values = ["${var.image_filter["tag_status"]}"]
   }
 }

--- a/data.tf
+++ b/data.tf
@@ -5,7 +5,7 @@ data "aws_ami" "latest_service_image" {
 
   filter {
     name   = "name"
-    values = ["${var.image_name_filter}"]
+    values = ["${var.image_filter.name}"]
   }
 
   filter {
@@ -20,6 +20,6 @@ data "aws_ami" "latest_service_image" {
 
   filter {
     name   = "Tag:Status"
-    values = ["${var.image_status}"]
+    values = ["${var.image_filter.tag_status}"]
   }
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -29,9 +29,8 @@ module "asg" {
     },
   ]
 
-  instance_type = "m5.large"
-  user_data     = "echo starting fprbe"
-  key_name      = ""
+  user_data = "echo starting fprbe"
+  key_name  = ""
 
   asg_vpc_zone_identifier  = ["subnet-a2b50c9d", "subnet-718c9efe"]
   asg_lb_target_group_arns = []

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -9,7 +9,7 @@ module "autoscaling-deployment" {
   application             = "java-7"
   product_domain          = "fprbe"
   description             = "fprbe instances"
-  asg_min_capacity        = 2
+  asg_min_capacity        = 0
   asg_vpc_zone_identifier = ["subnet-8270c222"]
 
   asg_tags = [

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -17,13 +17,13 @@ module "asg" {
   image_owners = ["123456789012"]
 
   image_filters = [
-    # See https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html for complete filter options
     {
+      # See https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html for complete filter options
       name   = "name"
       values = ["traveloka-fprbe-app-*"]
     },
-    # If you want to directly specify the image ID
     {
+      # If you want to directly specify the image ID
       name   = "image-id"
       values = ["ami-91920591023019"]
     },

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -2,34 +2,33 @@ provider "aws" {
   region = "ap-southeast-1"
 }
 
-module "autoscaling-deployment" {
-  source                  = "../.."
-  service_name            = "fprbe"
-  environment             = "staging"
-  application             = "java-7"
-  product_domain          = "fprbe"
-  description             = "fprbe instances"
-  asg_min_capacity        = 0
-  asg_vpc_zone_identifier = ["subnet-8270c222"]
+module "asg" {
+  source = "../.."
 
-  asg_tags = [
+  service_name   = "fprbe"
+  environment    = "production"
+  product_domain = "fpr"
+  description    = "Instances of fprbe-app"
+  application    = "java-8"
+
+  security_groups  = []
+  instance_profile = "myinstance-profile"
+
+  image_owners = ["123456789012"]
+
+  image_filters = [
     {
-      key                 = "AmiId"
-      value               = "ami-9893cee4"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "ServiceVersion"
-      value               = "0.1.0"
-      propagate_at_launch = true
+      name   = "name"
+      values = ["traveloka-fprbe-app-*"]
     },
   ]
 
-  asg_health_check_grace_period = 30
-  asg_health_check_type         = "EC2"
-  asg_wait_for_capacity_timeout = "4m"
-  lc_security_groups            = []
-  lc_instance_profile           = ""
-  lc_instance_type              = "t2.medium"
-  lc_ami_id                     = "ami-9893cee4"
+  instance_type = "m5.large"
+  user_data     = "echo starting fprbe"
+  key_name      = ""
+
+  asg_vpc_zone_identifier  = ["subnet-a2b50c9d", "subnet-718c9efe"]
+  asg_lb_target_group_arns = []
+
+  asg_wait_for_capacity_timeout = "1m"
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -17,9 +17,15 @@ module "asg" {
   image_owners = ["123456789012"]
 
   image_filters = [
+    # See https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html for complete filter options
     {
       name   = "name"
       values = ["traveloka-fprbe-app-*"]
+    },
+    # If you want to directly specify the image ID
+    {
+      name   = "image-id"
+      values = ["ami-91920591023019"]
     },
   ]
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  # Set the wait_for_elb_capacity to asg_min_capacity if not explicitly provided
+  asg_wait_for_elb_capacity = "${var.asg_wait_for_elb_capacity == "" ? var.asg_min_capacity : var.asg_wait_for_elb_capacity}"
+}

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "aws_autoscaling_group" "main" {
       ]
     }
 
-    instances_distribution = "${var.mixed_instances_distribution}"
+    instances_distribution = ["${var.mixed_instances_distribution}"]
   }
 
   tags = [

--- a/main.tf
+++ b/main.tf
@@ -22,10 +22,16 @@ module "random_lc" {
 }
 
 resource "aws_launch_template" "main" {
-  name                   = "${module.random_lc.name}"
-  image_id               = "${var.lc_ami_id}"
-  instance_type          = "${var.lc_instance_type}"
-  iam_instance_profile   = "${var.lc_instance_profile}"
+  name          = "${module.random_lc.name}"
+  image_id      = "${var.lc_ami_id}"
+  instance_type = "${var.lc_instance_type}"
+
+  iam_instance_profile {
+    name = "${var.lc_instance_profile}"
+
+    // TODO switch to ARN, more specific
+  }
+
   key_name               = "${var.lc_key_name}"
   vpc_security_group_ids = ["${var.lc_security_groups}"]
   user_data              = "${var.lc_user_data}"

--- a/main.tf
+++ b/main.tf
@@ -136,4 +136,8 @@ resource "aws_autoscaling_group" "main" {
   wait_for_capacity_timeout = "${var.asg_wait_for_capacity_timeout}"
   wait_for_elb_capacity     = "${local.asg_wait_for_elb_capacity}"
   service_linked_role_arn   = "${var.asg_service_linked_role_arn}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -4,11 +4,13 @@ module "launch_template_name" {
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "launch_configuration"
 }
+
 module "asg_name" {
   source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.16.1"
 
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "autoscaling_group"
+
   keepers = {
     image_id                  = "${data.aws_ami.latest_service_image.id}"
     instance_profile          = "${var.instance_profile}"

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,9 @@ module "random_name" {
 }
 
 resource "aws_launch_template" "main" {
-  name          = "${module.random_name.name}"
-  image_id      = "${data.aws_ami.latest_service_image.id}"
+  name = "${module.random_name.name}"
+
+  # image_id      = "${data.aws_ami.latest_service_image.id}"
   instance_type = "${var.instance_type}"
 
   iam_instance_profile {
@@ -75,7 +76,7 @@ resource "aws_autoscaling_group" "main" {
   mixed_instances_policy {
     launch_template {
       launch_template_specification {
-        launch_template_id = "${aws_launch_template.example.id}"
+        launch_template_id = "${aws_launch_template.main.id}"
         version            = "$Latest"
       }
 

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_launch_template" "main" {
 
   key_name               = "${var.key_name}"
   vpc_security_group_ids = ["${var.security_groups}"]
-  user_data              = "${var.user_data}"
+  user_data              = "${${base64encode(var.user_data)}"
 
   monitoring {
     enabled = "${var.monitoring}"
@@ -56,6 +56,7 @@ resource "aws_launch_template" "main" {
         Service       = "${var.service_name}"
         ProductDomain = "${var.product_domain}"
         Environment   = "${var.environment}"
+        ManagedBy     = "terraform"
       }
     },
   ]

--- a/main.tf
+++ b/main.tf
@@ -8,17 +8,6 @@ module "random_lc" {
 
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "launch_configuration"
-
-  keepers = {
-    lc_security_groups  = "${join(",",sort(var.lc_security_groups))}"
-    lc_instance_profile = "${var.lc_instance_profile}"
-    lc_key_name         = "${var.lc_key_name}"
-    lc_instance_type    = "${var.lc_instance_type}"
-    lc_ami_id           = "${var.lc_ami_id}"
-    lc_monitoring       = "${var.lc_monitoring}"
-    lc_ebs_optimized    = "${var.lc_ebs_optimized}"
-    lc_user_data        = "${var.lc_user_data}"
-  }
 }
 
 resource "aws_launch_template" "main" {

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,12 @@ resource "aws_launch_configuration" "main" {
   enable_monitoring    = "${var.lc_monitoring}"
   ebs_optimized        = "${var.lc_ebs_optimized}"
 
+  root_block_device = {
+    volume_size           = "${var.volume_size}"
+    volume_type           = "${var.volume_type}"
+    delete_on_termination = "${var.delete_on_termination}"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,10 @@ resource "aws_launch_template" "main" {
     name = "${var.instance_profile}"
   }
 
+  credit_specification {
+    cpu_credits = "${var.cpu_credits}"
+  }
+
   key_name               = "${var.key_name}"
   vpc_security_group_ids = ["${var.security_groups}"]
   user_data              = "${base64encode(var.user_data)}"

--- a/main.tf
+++ b/main.tf
@@ -9,22 +9,17 @@ resource "aws_launch_template" "main" {
   name = "${module.random_name.name}"
 
   # image_id      = "${data.aws_ami.latest_service_image.id}"
-  instance_type = "${var.instance_type}"
 
   iam_instance_profile {
     name = "${var.instance_profile}"
   }
-
   key_name               = "${var.key_name}"
   vpc_security_group_ids = ["${var.security_groups}"]
   user_data              = "${var.user_data}"
-
   monitoring {
     enabled = "${var.monitoring}"
   }
-
   ebs_optimized = "${var.ebs_optimized}"
-
   block_device_mappings {
     device_name = "/dev/sda1"
 
@@ -34,7 +29,6 @@ resource "aws_launch_template" "main" {
       delete_on_termination = "${var.delete_on_termination}"
     }
   }
-
   tag_specifications = [
     {
       resource_type = "instance"

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,8 @@ resource "aws_autoscaling_group" "main" {
         "${var.launch_template_overrides}",
       ]
     }
+
+    instances_distribution = "${var.mixed_instances_distribution}"
   }
 
   tags = [

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_launch_template" "main" {
 
   key_name               = "${var.key_name}"
   vpc_security_group_ids = ["${var.security_groups}"]
-  user_data              = "${${base64encode(var.user_data)}"
+  user_data              = "${base64encode(var.user_data)}"
 
   monitoring {
     enabled = "${var.monitoring}"

--- a/main.tf
+++ b/main.tf
@@ -8,18 +8,22 @@ module "random_name" {
 resource "aws_launch_template" "main" {
   name = "${module.random_name.name}"
 
-  # image_id      = "${data.aws_ami.latest_service_image.id}"
+  image_id = "${data.aws_ami.latest_service_image.id}"
 
   iam_instance_profile {
     name = "${var.instance_profile}"
   }
+
   key_name               = "${var.key_name}"
   vpc_security_group_ids = ["${var.security_groups}"]
   user_data              = "${var.user_data}"
+
   monitoring {
     enabled = "${var.monitoring}"
   }
+
   ebs_optimized = "${var.ebs_optimized}"
+
   block_device_mappings {
     device_name = "/dev/sda1"
 
@@ -29,6 +33,7 @@ resource "aws_launch_template" "main" {
       delete_on_termination = "${var.delete_on_termination}"
     }
   }
+
   tag_specifications = [
     {
       resource_type = "instance"

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,14 @@ resource "aws_launch_template" "main" {
     }
   }
 
+  tags = {
+    Name          = "${module.random_name.name}"
+    Service       = "${var.service_name}"
+    ProductDomain = "${var.product_domain}"
+    Environment   = "${var.environment}"
+    ManagedBy     = "terraform"
+  }
+
   tag_specifications = [
     {
       resource_type = "instance"
@@ -90,6 +98,11 @@ resource "aws_autoscaling_group" "main" {
     {
       key                 = "Name"
       value               = "${module.random_name.name}"
+      propagate_at_launch = false
+    },
+    {
+      key                 = "Service"
+      value               = "${var.service_name}"
       propagate_at_launch = false
     },
     {

--- a/variables.tf
+++ b/variables.tf
@@ -210,7 +210,7 @@ variable "delete_on_termination" {
 
 variable "mixed_instances_distribution" {
   type        = "map"
-  description = ""
+  description = "Specify the distribution of on-demand instances and spot instances. See https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstancesDistribution.html"
 
   default = {
     on_demand_allocation_strategy            = "prioritized"

--- a/variables.tf
+++ b/variables.tf
@@ -175,3 +175,20 @@ variable "lc_user_data" {
   default     = ""
   description = "The spawned instances will have this user data. Use the rendered value of a terraform's `template_cloudinit_config` data" // https://www.terraform.io/docs/providers/template/d/cloudinit_config.html#rendered
 }
+
+variable "volume_size" {
+  description = "The size of the volume in gigabytes"
+  type        = "string"
+  default     = "8"
+}
+
+variable "volume_type" {
+  description = "The type of volume. Can be standard, gp2, or io1"
+  type        = "string"
+  default     = "gp2"
+}
+
+variable "delete_on_termination" {
+  description = "Whether the volume should be destroyed on instance termination"
+  default     = "true"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -167,6 +167,7 @@ variable "instance_type" {
 
 variable "image_filter" {
   type        = "map"
+  default     = {}
   description = "The AMI search filter. The most recent AMI that pass this filter and  have the correct Service & Product Domain tag values will be selected to be deployed to the ASG. Currently, only name and tag_status keys are supported"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -132,6 +132,18 @@ variable "asg_wait_for_elb_capacity" {
   description = "Terraform will wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. If left to default, the value is set to asg_min_capacity"
 }
 
+variable "launch_template_overrides" {
+  type = "list"
+
+  default = [
+    {
+      "instance_type" = "m5.large"
+    },
+  ]
+
+  description = "List of nested arguments provides the ability to specify multiple instance types. See https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#override"
+}
+
 variable "security_groups" {
   type        = "list"
   description = "The spawned instances will have these security groups"

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "asg_lb_target_group_arns" {
 
 variable "asg_min_capacity" {
   type        = "string"
-  default     = 1
+  default     = 0
   description = "The created ASG will have this number of instances at minimum"
 }
 
 variable "asg_max_capacity" {
   type        = "string"
-  default     = 5
+  default     = 0
   description = "The created ASG will have this number of instances at maximum"
 }
 
@@ -60,13 +60,13 @@ variable "asg_health_check_type" {
 
 variable "asg_health_check_grace_period" {
   type        = "string"
-  default     = 300
+  default     = "300"
   description = "Time, in seconds, to wait for new instances before checking their health"
 }
 
 variable "asg_default_cooldown" {
   type        = "string"
-  default     = 300
+  default     = "300"
   description = "Time, in seconds, the minimum interval of two scaling activities"
 }
 
@@ -160,19 +160,19 @@ variable "lc_ami_id" {
 
 variable "lc_monitoring" {
   type        = "string"
-  default     = true
+  default     = "true"
   description = "The spawned instances will have enhanced monitoring if enabled"
 }
 
 variable "lc_ebs_optimized" {
   type        = "string"
-  default     = false
+  default     = "false"
   description = "The spawned instances will have EBS optimization if enabled"
 }
 
 variable "lc_user_data" {
   type        = "string"
-  default     = ""
+  default     = " "
   description = "The spawned instances will have this user data. Use the rendered value of a terraform's `template_cloudinit_config` data" // https://www.terraform.io/docs/providers/template/d/cloudinit_config.html#rendered
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -135,14 +135,7 @@ variable "asg_wait_for_elb_capacity" {
 variable "launch_template_overrides" {
   type = "list"
 
-  default = [
-    {
-      "instance_type" = "m5.large"
-    },
-    {
-      "instance_type" = "m4.large"
-    },
-  ]
+  default = []
 
   description = "List of nested arguments provides the ability to specify multiple instance types. See https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#override"
 }
@@ -170,7 +163,7 @@ variable "instance_type" {
 
 variable "image_filters" {
   type        = "list"
-  description = "The AMI search filters. The most recent AMI that pass this filter and have the correct Service & Product Domain tag values will be selected to be deployed to the ASG"
+  description = "The AMI search filters. The most recent AMI that pass this filter will be deployed to the ASG"
 }
 
 variable "image_owners" {

--- a/variables.tf
+++ b/variables.tf
@@ -163,11 +163,6 @@ variable "key_name" {
   description = "The spawned instances will have this SSH key name"
 }
 
-variable "instance_type" {
-  type        = "string"
-  description = "The spawned instances will have this type"
-}
-
 variable "image_filters" {
   type        = "list"
   description = "The AMI search filters. The most recent AMI that pass this filter will be deployed to the ASG"

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "asg_lb_target_group_arns" {
 
 variable "asg_min_capacity" {
   type        = "string"
-  default     = 0
+  default     = "0"
   description = "The created ASG will have this number of instances at minimum"
 }
 
 variable "asg_max_capacity" {
   type        = "string"
-  default     = 0
+  default     = "0"
   description = "The created ASG will have this number of instances at maximum"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -139,6 +139,9 @@ variable "launch_template_overrides" {
     {
       "instance_type" = "m5.large"
     },
+    {
+      "instance_type" = "m4.large"
+    },
   ]
 
   description = "List of nested arguments provides the ability to specify multiple instance types. See https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#override"

--- a/variables.tf
+++ b/variables.tf
@@ -163,6 +163,12 @@ variable "key_name" {
   description = "The spawned instances will have this SSH key name"
 }
 
+variable "cpu_credits" {
+  type        = "string"
+  default     = "unlimited"
+  description = "The credit option for CPU usage, can be either 'standard' or 'unlimited'"
+}
+
 variable "image_filters" {
   type        = "list"
   description = "The AMI search filters. The most recent AMI that pass this filter will be deployed to the ASG. See https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html"

--- a/variables.tf
+++ b/variables.tf
@@ -137,10 +137,10 @@ variable "launch_template_overrides" {
 
   default = [
     {
-      "instance_type" = "m5.large"
+      "instance_type" = "c5.large"
     },
     {
-      "instance_type" = "m4.large"
+      "instance_type" = "c4.large"
     },
   ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -165,7 +165,7 @@ variable "key_name" {
 
 variable "image_filters" {
   type        = "list"
-  description = "The AMI search filters. The most recent AMI that pass this filter will be deployed to the ASG"
+  description = "The AMI search filters. The most recent AMI that pass this filter will be deployed to the ASG. See https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html"
 }
 
 variable "image_owners" {

--- a/variables.tf
+++ b/variables.tf
@@ -153,9 +153,9 @@ variable "instance_type" {
   description = "The spawned instances will have this type"
 }
 
-variable "ami_id" {
+variable "image_name_filter" {
   type        = "string"
-  description = "The spawned instances will have this AMI"
+  description = "The AMI name filter. The ASG will be provisioned with the most recent AMI following this name filter"
 }
 
 variable "monitoring" {

--- a/variables.tf
+++ b/variables.tf
@@ -168,10 +168,10 @@ variable "instance_type" {
   description = "The spawned instances will have this type"
 }
 
-variable "image_filter" {
+variable "image_filters" {
   type        = "map"
   default     = {}
-  description = "The AMI search filter. The most recent AMI that pass this filter and  have the correct Service & Product Domain tag values will be selected to be deployed to the ASG. Currently, only name and tag_status keys are supported"
+  description = "The AMI search filters. The most recent AMI that pass this filter and have the correct Service & Product Domain tag values will be selected to be deployed to the ASG"
 }
 
 variable "monitoring" {

--- a/variables.tf
+++ b/variables.tf
@@ -135,7 +135,14 @@ variable "asg_wait_for_elb_capacity" {
 variable "launch_template_overrides" {
   type = "list"
 
-  default = []
+  default = [
+    {
+      "instance_type" = "m5.large"
+    },
+    {
+      "instance_type" = "m4.large"
+    },
+  ]
 
   description = "List of nested arguments provides the ability to specify multiple instance types. See https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#override"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -170,8 +170,12 @@ variable "instance_type" {
 
 variable "image_filters" {
   type        = "list"
-  default     = []
   description = "The AMI search filters. The most recent AMI that pass this filter and have the correct Service & Product Domain tag values will be selected to be deployed to the ASG"
+}
+
+variable "image_owners" {
+  type        = "list"
+  description = "List of AMI owners to limit search. This becomes required starting terraform-provider-aws v2 (https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#owners-argument-now-required)"
 }
 
 variable "monitoring" {

--- a/variables.tf
+++ b/variables.tf
@@ -118,7 +118,7 @@ variable "asg_termination_policies" {
 variable "asg_tags" {
   type        = "list"
   default     = []
-  description = "The created ASG (and spawned instances) will have these tags applied over the default ones (see main.tf)"
+  description = "The created ASG will have these tags applied over the default ones (see main.tf)"
 }
 
 variable "asg_wait_for_capacity_timeout" {
@@ -153,9 +153,9 @@ variable "instance_type" {
   description = "The spawned instances will have this type"
 }
 
-variable "image_name_filter" {
-  type        = "string"
-  description = "The AMI name filter. The ASG will be provisioned with the most recent AMI following this name filter"
+variable "image_filter" {
+  type        = "map"
+  description = "The AMI search filter. The most recent AMI that pass this filter and  have the correct Service & Product Domain tag values will be selected to be deployed to the ASG. Currently, only name and tag_status keys are supported"
 }
 
 variable "monitoring" {

--- a/variables.tf
+++ b/variables.tf
@@ -118,7 +118,7 @@ variable "asg_termination_policies" {
 variable "asg_tags" {
   type        = "list"
   default     = []
-  description = "The created ASG (and spawned instances) will have these tags, merged over the default (see main.tf)"
+  description = "The created ASG (and spawned instances) will have these tags applied over the default ones (see main.tf)"
 }
 
 variable "asg_wait_for_capacity_timeout" {
@@ -132,45 +132,45 @@ variable "asg_wait_for_elb_capacity" {
   description = "Terraform will wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. If left to default, the value is set to asg_min_capacity"
 }
 
-variable "lc_security_groups" {
+variable "security_groups" {
   type        = "list"
   description = "The spawned instances will have these security groups"
 }
 
-variable "lc_instance_profile" {
+variable "instance_profile" {
   type        = "string"
   description = "The spawned instances will have this IAM profile"
 }
 
-variable "lc_key_name" {
+variable "key_name" {
   type        = "string"
   default     = ""
   description = "The spawned instances will have this SSH key name"
 }
 
-variable "lc_instance_type" {
+variable "instance_type" {
   type        = "string"
   description = "The spawned instances will have this type"
 }
 
-variable "lc_ami_id" {
+variable "ami_id" {
   type        = "string"
   description = "The spawned instances will have this AMI"
 }
 
-variable "lc_monitoring" {
+variable "monitoring" {
   type        = "string"
   default     = "true"
   description = "The spawned instances will have enhanced monitoring if enabled"
 }
 
-variable "lc_ebs_optimized" {
+variable "ebs_optimized" {
   type        = "string"
   default     = "false"
   description = "The spawned instances will have EBS optimization if enabled"
 }
 
-variable "lc_user_data" {
+variable "user_data" {
   type        = "string"
   default     = " "
   description = "The spawned instances will have this user data. Use the rendered value of a terraform's `template_cloudinit_config` data" // https://www.terraform.io/docs/providers/template/d/cloudinit_config.html#rendered

--- a/variables.tf
+++ b/variables.tf
@@ -207,3 +207,17 @@ variable "delete_on_termination" {
   description = "Whether the volume should be destroyed on instance termination"
   default     = "true"
 }
+
+variable "mixed_instances_distribution" {
+  type        = "map"
+  description = ""
+
+  default = {
+    on_demand_allocation_strategy            = "prioritized"
+    on_demand_base_capacity                  = "0"
+    on_demand_percentage_above_base_capacity = "100"
+    spot_allocation_strategy                 = "lowest-price"
+    spot_instance_pools                      = "2"
+    spot_max_price                           = ""
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -169,8 +169,8 @@ variable "instance_type" {
 }
 
 variable "image_filters" {
-  type        = "map"
-  default     = {}
+  type        = "list"
+  default     = []
   description = "The AMI search filters. The most recent AMI that pass this filter and have the correct Service & Product Domain tag values will be selected to be deployed to the ASG"
 }
 


### PR DESCRIPTION
- Enable mixing instance types
- Enable mixing on-demand and spot instances
- Enable T instance family's unlimited burst
- Enable EC2 volumes tagging and launch template tag (previously only ASG + its instances)