### PR TITLE
switch to name prefix to prevent terraform deletion issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,7 +95,7 @@ resource "aws_launch_template" "main" {
 }
 
 resource "aws_autoscaling_group" "main" {
-  name                      = "${module.asg_name.name}"
+  name_prefix               = "${module.asg_name.name}"
   max_size                  = "${var.asg_max_capacity}"
   min_size                  = "${var.asg_min_capacity}"
   default_cooldown          = "${var.asg_default_cooldown}"


### PR DESCRIPTION
There's a bug when using this module to deploy AMI to an ASG. 
If a deployment fails when the ASG is already created[1] and the same terraform code is executed again [2] (e.g. the requested instance type was not available during [1]), terraform will fail the execution saying that the ASG with the same name exists. If the conflicting ASG is deleted externally and `terraform apply` is executed again, terraform will [create a new ASG, and then destroy it right away](https://github.com/hashicorp/terraform/issues/20360). This is dangerous as it means there will be a downtime (no ASGs -> no instances).