### PR TITLE
Use "ref" instead of "version" to lock instance_profile module in the example

### DIFF
--- a/examples/simple/02-instance_role.tf
+++ b/examples/simple/02-instance_role.tf
@@ -1,6 +1,5 @@
 module "instance_profile" {
-  source  = "github.com/traveloka/terraform-aws-iam-role.git//modules/instance"
-  version = "v1.0.1"
+  source = "github.com/traveloka/terraform-aws-iam-role.git//modules/instance?ref=v1.0.1"
 
   service_name   = "fprbe"
   cluster_role   = "app"


### PR DESCRIPTION
Github source doesn't support version constraints:
    
* terraform 0.11.14 ignores the version constraints and loads latest version
    
> Initializing modules...
> - module.instance_profile
>   Getting source "github.com/traveloka/terraform-aws-iam-role.git//modules/instance"
    
* terraform 0.12.6 fails with
    
> Error: Invalid version constraint
>
> Cannot apply a version constraint to module "instance_profile" (at
> 02-instance_role.tf:1) because it has a non Registry URL.

<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

* Lock instance_profile module in the example
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform init

Initializing modules...
- module.instance_profile
  Getting source "github.com/traveloka/terraform-aws-iam-role.git//modules/instance?ref=v1.0.1"
- module.asg
  Getting source "../../"
- module.instance_profile.this
  Getting source "../../"
- module.asg.launch_template_name
  Getting source "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.16.1"
- module.asg.asg_name
  Getting source "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.16.1"

Initializing provider plugins...
- Checking for available provider plugins on https://releases.hashicorp.com...
- Downloading plugin for provider "template" (2.1.2)...
- Downloading plugin for provider "aws" (2.22.0)...
- Downloading plugin for provider "random" (2.1.2)...
- Downloading plugin for provider "null" (2.1.2)...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.aws: version = "~> 2.22"
* provider.template: version = "~> 2.1"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
