### PR TITLE
Terraform 0.12: update resource-naming to v0.17.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,11 @@
 module "launch_template_name" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.16.1"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.17.0"
 
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "launch_configuration"
 }
 module "asg_name" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.16.1"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.17.0"
 
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "autoscaling_group"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #25 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

* Fix "Argument names must not be quoted." during resource-naming module init
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform init
Initializing modules...
Downloading github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.17.0 for asg.asg_name...
- asg.asg_name in .terraform/modules/asg.asg_name
Downloading github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.17.0 for asg.launch_template_name...
- asg.launch_template_name in .terraform/modules/asg.launch_template_name

Initializing the backend...

Initializing provider plugins...
- Checking for available provider plugins...
- Downloading plugin for provider "random" (terraform-providers/random) 2.1.2...
- Downloading plugin for provider "aws" (terraform-providers/aws) 2.22.0...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.aws: version = "~> 2.22"

Terraform has been successfully initialized!

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
