### PR TITLE
Terraform 0.12: add cpu_credits variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,10 @@ resource "aws_launch_template" "main" {
     name = "${var.instance_profile}"
   }
 
+  credit_specification {
+    cpu_credits = var.cpu_credits
+  }
+
   key_name               = "${var.key_name}"
   vpc_security_group_ids = var.security_groups
   user_data              = "${base64encode(var.user_data)}"

--- a/variables.tf
+++ b/variables.tf
@@ -163,6 +163,12 @@ variable "key_name" {
   description = "The spawned instances will have this SSH key name"
 }
 
+variable "cpu_credits" {
+  type        = string
+  default     = "unlimited"
+  description = "The credit option for CPU usage, can be either 'standard' or 'unlimited'"
+}
+
 variable "image_filters" {
   type        = "list"
   description = "The AMI search filters. The most recent AMI that pass this filter will be deployed to the ASG. See https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-images.html"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #26 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
ENHANCEMENTS:

* feature: Allow setting cpu_credits
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan
 # module.app.module.asg.aws_launch_template.main will be created
~~~
  + resource "aws_launch_template" "main" {
~~~
      + credit_specification {
          + cpu_credits = "standard"
        }
~~~
     }
~~~
```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
