### PR TITLE
change var name from instance_profile to instance_profile_name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ module "asg_name" {
 
   keepers = {
     image_id                  = "${data.aws_ami.latest_service_image.id}"
-    instance_profile          = "${var.instance_profile}"
+    instance_profile          = "${var.instance_profile_name}"
     key_name                  = "${var.key_name}"
     security_groups           = "${join(",", sort(var.security_groups))}"
     user_data                 = "${var.user_data}"
@@ -31,7 +31,7 @@ resource "aws_launch_template" "main" {
   image_id = "${data.aws_ami.latest_service_image.id}"
 
   iam_instance_profile {
-    name = "${var.instance_profile}"
+    name = "${var.instance_profile_name}"
   }
 
   credit_specification {

--- a/variables.tf
+++ b/variables.tf
@@ -158,7 +158,7 @@ variable "security_groups" {
   description = "The spawned instances will have these security groups"
 }
 
-variable "instance_profile" {
+variable "instance_profile_name" {
   type        = "string"
   description = "The spawned instances will have this IAM profile"
 }


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #0000
improve var name to avoid confusion
***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->
change var name from instance_profile to instance_profile_name
```release-note
NOTES:

* Any Notes regarding your submitted PR, like breaking changes or else.

FEATURES:

* **New Source:** `aws_000_0000` ([#references_to_issue](./))

ENHANCEMENTS:

* feature: Add support for new version of AWS API

BUG FIXES:

* Prevent error from evil bugs
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
