### PR TITLE
Remove executable_users from aws_ami data source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.2.3 (Aug 29, 2019)
+
+NOTES:
+
+* Remove `executable_users` option from aws_ami data source (#31)
+
 ## v0.2.2 (Jun 28, 2019)
 
 NOTES:

--- a/data.tf
+++ b/data.tf
@@ -1,5 +1,4 @@
 data "aws_ami" "latest_service_image" {
-  executable_users = ["self"]
   owners           = ["${var.image_owners}"]
   most_recent      = true
 

--- a/data.tf
+++ b/data.tf
@@ -1,6 +1,6 @@
 data "aws_ami" "latest_service_image" {
-  owners           = ["${var.image_owners}"]
-  most_recent      = true
+  owners      = ["${var.image_owners}"]
+  most_recent = true
 
   filter = [
     "${var.image_filters}",


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #30 

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

* Remove executable_users from aws_ami data source
```

***

Output from `terraform plan` command from changes you propose.

```
$ N/A

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
