### PR TITLE
enable smooth switching between mixed instance policy and plain launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ resource "aws_launch_template" "main" {
   name = module.launch_template_name.name
 
   image_id = data.aws_ami.latest_service_image.id
-
+  instance_type = var.use_mixed_instances_policy == true ? null : var.launch_template_overrides[0].instance_type
   iam_instance_profile {
     name = var.instance_profile_name
   }

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ module "asg_name" {
 resource "aws_launch_template" "main" {
   name = module.launch_template_name.name
 
-  image_id = data.aws_ami.latest_service_image.id
+  image_id      = data.aws_ami.latest_service_image.id
   instance_type = var.use_mixed_instances_policy == true ? null : var.launch_template_overrides[0].instance_type
   iam_instance_profile {
     name = var.instance_profile_name
@@ -119,7 +119,7 @@ resource "aws_autoscaling_group" "main" {
   }
 
   dynamic "mixed_instances_policy" {
-    for_each = var.use_mixed_instances_policy == true ? ["use mixed instance policy"] :  []
+    for_each = var.use_mixed_instances_policy == true ? ["use mixed instance policy"] : []
     content {
       launch_template {
         launch_template_specification {

--- a/main.tf
+++ b/main.tf
@@ -109,31 +109,43 @@ resource "aws_autoscaling_group" "main" {
   load_balancers            = var.asg_clb_names
   termination_policies      = var.asg_termination_policies
 
-  mixed_instances_policy {
-    launch_template {
-      launch_template_specification {
-        launch_template_id = aws_launch_template.main.id
-        version            = "$Latest"
-      }
 
-      dynamic "override" {
-        for_each = var.launch_template_overrides
-        content {
-          instance_type     = lookup(override.value, "instance_type", null)
-          weighted_capacity = lookup(override.value, "weighted_capacity", null)
+  dynamic "launch_template" {
+    for_each = var.use_mixed_instances_policy == false ? ["use plain launch template"] : []
+    content {
+      id      = aws_launch_template.main.id
+      version = "$Latest"
+    }
+  }
+
+  dynamic "mixed_instances_policy" {
+    for_each = var.use_mixed_instances_policy == true ? ["use mixed instance policy"] :  []
+    content {
+      launch_template {
+        launch_template_specification {
+          launch_template_id = aws_launch_template.main.id
+          version            = "$Latest"
+        }
+
+        dynamic "override" {
+          for_each = var.launch_template_overrides
+          content {
+            instance_type     = lookup(override.value, "instance_type", null)
+            weighted_capacity = lookup(override.value, "weighted_capacity", null)
+          }
         }
       }
-    }
 
-    dynamic "instances_distribution" {
-      for_each = [var.mixed_instances_distribution]
-      content {
-        on_demand_allocation_strategy            = lookup(instances_distribution.value, "on_demand_allocation_strategy", null)
-        on_demand_base_capacity                  = lookup(instances_distribution.value, "on_demand_base_capacity", null)
-        on_demand_percentage_above_base_capacity = lookup(instances_distribution.value, "on_demand_percentage_above_base_capacity", null)
-        spot_allocation_strategy                 = lookup(instances_distribution.value, "spot_allocation_strategy", null)
-        spot_instance_pools                      = lookup(instances_distribution.value, "spot_instance_pools", null)
-        spot_max_price                           = lookup(instances_distribution.value, "spot_max_price", null)
+      dynamic "instances_distribution" {
+        for_each = [var.mixed_instances_distribution]
+        content {
+          on_demand_allocation_strategy            = lookup(instances_distribution.value, "on_demand_allocation_strategy", null)
+          on_demand_base_capacity                  = lookup(instances_distribution.value, "on_demand_base_capacity", null)
+          on_demand_percentage_above_base_capacity = lookup(instances_distribution.value, "on_demand_percentage_above_base_capacity", null)
+          spot_allocation_strategy                 = lookup(instances_distribution.value, "spot_allocation_strategy", null)
+          spot_instance_pools                      = lookup(instances_distribution.value, "spot_instance_pools", null)
+          spot_max_price                           = lookup(instances_distribution.value, "spot_max_price", null)
+        }
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -150,7 +150,10 @@ variable "launch_template_overrides" {
     },
   ]
 
-  description = "List of nested arguments provides the ability to specify multiple instance types. See https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#override"
+  description = """
+  List of nested arguments provides the ability to specify multiple instance types. See https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#override
+  When using plain launch template, the first element's instance_type will be used as the launch template instance type.
+  """
 }
 
 variable "security_groups" {

--- a/variables.tf
+++ b/variables.tf
@@ -234,6 +234,12 @@ variable "associate_public_ip" {
   default     = "false"
 }
 
+variable "use_mixed_instances_policy" {
+  type = bool
+  description = "Whether to use ASG mixed instances policy or the plain launch template"
+  default     = true
+}
+
 variable "mixed_instances_distribution" {
   type        = map(string)
   description = "Specify the distribution of on-demand instances and spot instances. See https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_InstancesDistribution.html"

--- a/variables.tf
+++ b/variables.tf
@@ -150,10 +150,10 @@ variable "launch_template_overrides" {
     },
   ]
 
-  description = """
+  description = <<EOT
   List of nested arguments provides the ability to specify multiple instance types. See https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#override
   When using plain launch template, the first element's instance_type will be used as the launch template instance type.
-  """
+  EOT
 }
 
 variable "security_groups" {
@@ -238,7 +238,7 @@ variable "associate_public_ip" {
 }
 
 variable "use_mixed_instances_policy" {
-  type = bool
+  type        = bool
   description = "Whether to use ASG mixed instances policy or the plain launch template"
   default     = true
 }


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

FEATURES:
Make mixed instance policy optional, i.e. use vanilla launch template instead

ENHANCEMENTS:

BUG FIXES:
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
