### PR TITLE
Move security group to network interfaces in launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,11 +39,11 @@ resource "aws_launch_template" "main" {
   }
 
   key_name               = var.key_name
-  vpc_security_group_ids = var.security_groups
   user_data              = base64encode(var.user_data)
 
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip
+    security_groups = var.security_groups
   }
 
   monitoring {


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Issues : https://github.com/traveloka/terraform-aws-autoscaling/issues/38
***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

BUG FIXES:

* Fix Error creating AutoScaling Group: InvalidQueryParameter: Invalid launch template: When a network interface is provided, the security groups must be a part of it.
```

***

Output from `terraform plan` command from changes you propose.

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
