### PR TITLE
adding variable to optionally allowing disabling api termination

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,7 @@ resource "aws_launch_template" "main" {
     enabled = var.monitoring
   }
 
+  disable_api_termination = var.disable_api_termination
   ebs_optimized = var.ebs_optimized
 
   block_device_mappings {

--- a/variables.tf
+++ b/variables.tf
@@ -256,3 +256,9 @@ variable "mixed_instances_distribution" {
     spot_max_price                           = ""
   }
 }
+
+variable "disable_api_termination" {
+  type        = bool
+  description = "whether to protect your instance from accidently being terminated from console or api"
+  default     = false
+}


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
AWS provides a feature called "Disable api termination" for EC2 instances to help protect against accidental termination of instances via console, command line or an api. This is especially useful for datastores residing in normal ec2 instances where the teams cannot afford to loose their data. This PR gives an option to anyone using this module to set the boolean `disable_api_termination` true if they need to have this enabled. It will default to false if not provided.

--->

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

release-note

ENHANCEMENTS:

* feature: Add support to enable "disable_api_termination" for ec2 instances


***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
