### PR TITLE
Upgrade Terraform v0.12 Syntax for Launch Configuration

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -12,7 +12,8 @@ module "autoscaling-deployment" {
   asg_min_capacity        = 2
   asg_vpc_zone_identifier = ["subnet-8270c222"]
 
-  asg_tags = [
+  asg_tags = concat(
+   list(
     {
       key                 = "AmiId"
       value               = "ami-9893cee4"
@@ -22,8 +23,9 @@ module "autoscaling-deployment" {
       key                 = "ServiceVersion"
       value               = "0.1.0"
       propagate_at_launch = true
-    },
-  ]
+    }
+   ),
+  )
 
   asg_health_check_grace_period = 30
   asg_health_check_type         = "EC2"
@@ -33,3 +35,4 @@ module "autoscaling-deployment" {
   lc_instance_type              = "t2.medium"
   lc_ami_id                     = "ami-9893cee4"
 }
+

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 module "random_lc" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.19.0"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.19.1"
 
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "launch_configuration"

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,12 @@ resource "aws_launch_configuration" "main" {
   enable_monitoring    = "${var.lc_monitoring}"
   ebs_optimized        = "${var.lc_ebs_optimized}"
 
+  root_block_device = {
+    volume_size           = "${var.volume_size}"
+    volume_type           = "${var.volume_type}"
+    delete_on_termination = "${var.delete_on_termination}"
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -38,12 +38,6 @@ resource "aws_launch_configuration" "main" {
     delete_on_termination = var.delete_on_termination
   }
 
-  root_block_device = {
-    volume_size           = "${var.volume_size}"
-    volume_type           = "${var.volume_type}"
-    delete_on_termination = "${var.delete_on_termination}"
-  }
-
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -114,6 +114,10 @@ resource "aws_autoscaling_group" "main" {
 
     ignore_changes = [
       "launch_configuration",
+      "max_size",
+      "min_size",
+      "health_check_grace_period",
+      "health_check_type",
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,41 +1,41 @@
 locals {
   # Set the wait_for_elb_capacity to asg_min_capacity if not explicitly provided
-  asg_wait_for_elb_capacity = "${var.asg_wait_for_elb_capacity == "" ? var.asg_min_capacity : var.asg_wait_for_elb_capacity}"
+  asg_wait_for_elb_capacity = var.asg_wait_for_elb_capacity == "" ? var.asg_min_capacity : var.asg_wait_for_elb_capacity
 }
 
 module "random_lc" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.6.0"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.19.0"
 
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "launch_configuration"
 
   keepers = {
-    lc_security_groups  = "${join(",",sort(var.lc_security_groups))}"
-    lc_instance_profile = "${var.lc_instance_profile}"
-    lc_key_name         = "${var.lc_key_name}"
-    lc_instance_type    = "${var.lc_instance_type}"
-    lc_ami_id           = "${var.lc_ami_id}"
-    lc_monitoring       = "${var.lc_monitoring}"
-    lc_ebs_optimized    = "${var.lc_ebs_optimized}"
-    lc_user_data        = "${var.lc_user_data}"
+    lc_security_groups  = join(",", sort(var.lc_security_groups))
+    lc_instance_profile = var.lc_instance_profile
+    lc_key_name         = var.lc_key_name
+    lc_instance_type    = var.lc_instance_type
+    lc_ami_id           = var.lc_ami_id
+    lc_monitoring       = var.lc_monitoring
+    lc_ebs_optimized    = var.lc_ebs_optimized
+    lc_user_data        = var.lc_user_data
   }
 }
 
 resource "aws_launch_configuration" "main" {
-  name                 = "${module.random_lc.name}"
-  image_id             = "${var.lc_ami_id}"
-  instance_type        = "${var.lc_instance_type}"
-  iam_instance_profile = "${var.lc_instance_profile}"
-  key_name             = "${var.lc_key_name}"
-  security_groups      = ["${var.lc_security_groups}"]
-  user_data            = "${var.lc_user_data}"
-  enable_monitoring    = "${var.lc_monitoring}"
-  ebs_optimized        = "${var.lc_ebs_optimized}"
+  name                 = module.random_lc.name
+  image_id             = var.lc_ami_id
+  instance_type        = var.lc_instance_type
+  iam_instance_profile = var.lc_instance_profile
+  key_name             = var.lc_key_name
+  security_groups      = var.lc_security_groups
+  user_data            = var.lc_user_data
+  enable_monitoring    = var.lc_monitoring
+  ebs_optimized        = var.lc_ebs_optimized
 
-  root_block_device = {
-    volume_size           = "${var.volume_size}"
-    volume_type           = "${var.volume_type}"
-    delete_on_termination = "${var.delete_on_termination}"
+  root_block_device {
+    volume_size           = var.volume_size
+    volume_type           = var.volume_type
+    delete_on_termination = var.delete_on_termination
   }
 
   lifecycle {
@@ -44,26 +44,27 @@ resource "aws_launch_configuration" "main" {
 }
 
 resource "aws_autoscaling_group" "main" {
-  name                      = "${aws_launch_configuration.main.name}"
-  max_size                  = "${var.asg_max_capacity}"
-  min_size                  = "${var.asg_min_capacity}"
-  default_cooldown          = "${var.asg_default_cooldown}"
-  launch_configuration      = "${aws_launch_configuration.main.name}"
-  health_check_grace_period = "${var.asg_health_check_grace_period}"
-  health_check_type         = "${var.asg_health_check_type}"
-  vpc_zone_identifier       = ["${var.asg_vpc_zone_identifier}"]
-  target_group_arns         = ["${var.asg_lb_target_group_arns}"]
-  termination_policies      = ["${var.asg_termination_policies}"]
+  name                      = aws_launch_configuration.main.name
+  max_size                  = var.asg_max_capacity
+  min_size                  = var.asg_min_capacity
+  default_cooldown          = var.asg_default_cooldown
+  launch_configuration      = aws_launch_configuration.main.name
+  health_check_grace_period = var.asg_health_check_grace_period
+  health_check_type         = var.asg_health_check_type
+  vpc_zone_identifier       = var.asg_vpc_zone_identifier
+  target_group_arns         = var.asg_lb_target_group_arns
+  termination_policies      = var.asg_termination_policies
 
-  tags = [
+  tags = concat(
+   list( 
     {
       key                 = "Name"
-      value               = "${aws_launch_configuration.main.name}"
+      value               = aws_launch_configuration.main.name
       propagate_at_launch = true
     },
     {
       key                 = "Service"
-      value               = "${var.service_name}"
+      value               = var.service_name
       propagate_at_launch = true
     },
     {
@@ -73,51 +74,50 @@ resource "aws_autoscaling_group" "main" {
     },
     {
       key                 = "Environment"
-      value               = "${var.environment}"
+      value               = var.environment
       propagate_at_launch = true
     },
     {
       key                 = "ProductDomain"
-      value               = "${var.product_domain}"
+      value               = var.product_domain
       propagate_at_launch = true
     },
     {
       key                 = "Application"
-      value               = "${var.application}"
+      value               = var.application
       propagate_at_launch = true
     },
     {
       key                 = "Description"
-      value               = "${var.description}"
+      value               = var.description
       propagate_at_launch = true
     },
     {
       key                 = "ManagedBy"
       value               = "terraform"
       propagate_at_launch = true
-    },
-  ]
+    }
+   ),
+   var.asg_tags
+  )
 
-  tags = [
-    "${var.asg_tags}",
-  ]
-
-  placement_group           = "${var.asg_placement_group}"
-  metrics_granularity       = "${var.asg_metrics_granularity}"
-  enabled_metrics           = "${var.asg_enabled_metrics}"
-  wait_for_capacity_timeout = "${var.asg_wait_for_capacity_timeout}"
-  wait_for_elb_capacity     = "${local.asg_wait_for_elb_capacity}"
-  service_linked_role_arn   = "${var.asg_service_linked_role_arn}"
+  placement_group           = var.asg_placement_group
+  metrics_granularity       = var.asg_metrics_granularity
+  enabled_metrics           = var.asg_enabled_metrics
+  wait_for_capacity_timeout = var.asg_wait_for_capacity_timeout
+  wait_for_elb_capacity     = local.asg_wait_for_elb_capacity
+  service_linked_role_arn   = var.asg_service_linked_role_arn
 
   lifecycle {
     create_before_destroy = true
 
     ignore_changes = [
-      "launch_configuration",
-      "max_size",
-      "min_size",
-      "health_check_grace_period",
-      "health_check_type",
+      launch_configuration,
+      max_size,
+      min_size,
+      health_check_grace_period,
+      health_check_type,
     ]
   }
 }
+

--- a/main.tf
+++ b/main.tf
@@ -93,7 +93,7 @@ resource "aws_autoscaling_group" "main" {
     },
     {
       key                 = "ManagedBy"
-      value               = "Terraform"
+      value               = "terraform"
       propagate_at_launch = true
     },
   ]

--- a/main.tf
+++ b/main.tf
@@ -105,5 +105,9 @@ resource "aws_autoscaling_group" "main" {
 
   lifecycle {
     create_before_destroy = true
+
+    ignore_changes = [
+      "launch_configuration",
+    ]
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,10 @@
 output "asg_desired_capacity" {
-  value       = "${aws_autoscaling_group.main.desired_capacity}"
+  value       = aws_autoscaling_group.main.desired_capacity
   description = "The desired capacity of the auto scaling group; it may be useful when doing blue/green asg deployment (create a new asg while copying the old's capacity)"
 }
 
 output "asg_name" {
-  value       = "${aws_autoscaling_group.main.name}"
+  value       = aws_autoscaling_group.main.name
   description = "The name of the auto scaling group"
 }
+

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,3 @@
+provider "random" {
+  version = ">= 1.2.0, < 3.0.0"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -175,3 +175,20 @@ variable "lc_user_data" {
   default     = ""
   description = "The spawned instances will have this user data. Use the rendered value of a terraform's `template_cloudinit_config` data" // https://www.terraform.io/docs/providers/template/d/cloudinit_config.html#rendered
 }
+
+variable "volume_size" {
+  description = "The size of the volume in gigabytes"
+  type        = "string"
+  default     = "8"
+}
+
+variable "volume_type" {
+  description = "The type of volume. Can be standard, gp2, or io1"
+  type        = "string"
+  default     = "gp2"
+}
+
+variable "delete_on_termination" {
+  description = "Whether the volume should be destroyed on instance termination"
+  default     = "true"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "asg_lb_target_group_arns" {
 
 variable "asg_min_capacity" {
   type        = "string"
-  default     = 1
+  default     = "0"
   description = "The created ASG will have this number of instances at minimum"
 }
 
 variable "asg_max_capacity" {
   type        = "string"
-  default     = 5
+  default     = "0"
   description = "The created ASG will have this number of instances at maximum"
 }
 
@@ -60,13 +60,13 @@ variable "asg_health_check_type" {
 
 variable "asg_health_check_grace_period" {
   type        = "string"
-  default     = 300
+  default     = "300"
   description = "Time, in seconds, to wait for new instances before checking their health"
 }
 
 variable "asg_default_cooldown" {
   type        = "string"
-  default     = 300
+  default     = "300"
   description = "Time, in seconds, the minimum interval of two scaling activities"
 }
 
@@ -160,19 +160,19 @@ variable "lc_ami_id" {
 
 variable "lc_monitoring" {
   type        = "string"
-  default     = true
+  default     = "true"
   description = "The spawned instances will have enhanced monitoring if enabled"
 }
 
 variable "lc_ebs_optimized" {
   type        = "string"
-  default     = false
+  default     = "false"
   description = "The spawned instances will have EBS optimization if enabled"
 }
 
 variable "lc_user_data" {
   type        = "string"
-  default     = ""
+  default     = " "
   description = "The spawned instances will have this user data. Use the rendered value of a terraform's `template_cloudinit_config` data" // https://www.terraform.io/docs/providers/template/d/cloudinit_config.html#rendered
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,89 +1,89 @@
 variable "service_name" {
-  type        = "string"
+  type        = string
   description = "The name of the service"
 }
 
 variable "cluster_role" {
-  type        = "string"
+  type        = string
   default     = "app"
   description = "Primary role/function of the cluster"
 }
 
 variable "environment" {
-  type        = "string"
+  type        = string
   description = "The created resources will belong to this infrastructure environment"
 }
 
 variable "application" {
-  type        = "string"
+  type        = string
   description = "Application type that the ASG's instances will serve"
 }
 
 variable "product_domain" {
-  type        = "string"
+  type        = string
   description = "Abbreviation of the product domain this ASG and its instances belongs to"
 }
 
 variable "description" {
-  type        = "string"
+  type        = string
   description = "Free form description of this ASG and its instances"
 }
 
 variable "asg_vpc_zone_identifier" {
-  type        = "list"
+  type        = list(string)
   description = "The created ASG will spawn instances to these subnet IDs"
 }
 
 variable "asg_lb_target_group_arns" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "The created ASG will be attached to this target group"
 }
 
 variable "asg_min_capacity" {
-  type        = "string"
+  type        = string
   default     = "0"
   description = "The created ASG will have this number of instances at minimum"
 }
 
 variable "asg_max_capacity" {
-  type        = "string"
+  type        = string
   default     = "0"
   description = "The created ASG will have this number of instances at maximum"
 }
 
 variable "asg_health_check_type" {
-  type        = "string"
+  type        = string
   default     = "ELB"
   description = "Controls how ASG health checking is done"
 }
 
 variable "asg_health_check_grace_period" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "Time, in seconds, to wait for new instances before checking their health"
 }
 
 variable "asg_default_cooldown" {
-  type        = "string"
+  type        = string
   default     = "300"
   description = "Time, in seconds, the minimum interval of two scaling activities"
 }
 
 variable "asg_placement_group" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The placement group for the spawned instances"
 }
 
 variable "asg_metrics_granularity" {
-  type        = "string"
+  type        = string
   default     = "1Minute"
   description = "The granularity to associate with the metrics to collect"
 }
 
 variable "asg_enabled_metrics" {
-  type = "list"
+  type = list(string)
 
   default = [
     "GroupMinSize",
@@ -100,13 +100,13 @@ variable "asg_enabled_metrics" {
 }
 
 variable "asg_service_linked_role_arn" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The ARN of the service-linked role that the ASG will use to call other AWS services"
 }
 
 variable "asg_termination_policies" {
-  type = "list"
+  type = list(string)
 
   default = [
     "Default",
@@ -116,75 +116,75 @@ variable "asg_termination_policies" {
 }
 
 variable "asg_tags" {
-  type        = "list"
+  type        = list(map(string))
   default     = []
   description = "The created ASG (and spawned instances) will have these tags, merged over the default (see main.tf)"
 }
 
 variable "asg_wait_for_capacity_timeout" {
-  type        = "string"
+  type        = string
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out"
 }
 
 variable "asg_wait_for_elb_capacity" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Terraform will wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. If left to default, the value is set to asg_min_capacity"
 }
 
 variable "lc_security_groups" {
-  type        = "list"
+  type        = list(string)
   description = "The spawned instances will have these security groups"
 }
 
 variable "lc_instance_profile" {
-  type        = "string"
+  type        = string
   description = "The spawned instances will have this IAM profile"
 }
 
 variable "lc_key_name" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The spawned instances will have this SSH key name"
 }
 
 variable "lc_instance_type" {
-  type        = "string"
+  type        = string
   description = "The spawned instances will have this type"
 }
 
 variable "lc_ami_id" {
-  type        = "string"
+  type        = string
   description = "The spawned instances will have this AMI"
 }
 
 variable "lc_monitoring" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "The spawned instances will have enhanced monitoring if enabled"
 }
 
 variable "lc_ebs_optimized" {
-  type        = "string"
+  type        = string
   default     = "false"
   description = "The spawned instances will have EBS optimization if enabled"
 }
 
 variable "lc_user_data" {
-  type        = "string"
+  type        = string
   default     = " "
   description = "The spawned instances will have this user data. Use the rendered value of a terraform's `template_cloudinit_config` data" // https://www.terraform.io/docs/providers/template/d/cloudinit_config.html#rendered
 }
 
 variable "volume_size" {
   description = "The size of the volume in gigabytes"
-  type        = "string"
+  type        = string
   default     = "8"
 }
 
 variable "volume_type" {
   description = "The type of volume. Can be standard, gp2, or io1"
-  type        = "string"
+  type        = string
   default     = "gp2"
 }
 
@@ -192,3 +192,4 @@ variable "delete_on_termination" {
   description = "Whether the volume should be destroyed on instance termination"
   default     = "true"
 }
+


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #0000

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Upgrade Terraform v0.12 syntax for Launch Configuration. Release version use suffix `-rolling`

ENHANCEMENTS:

* feature: Add support for Terraform v0.12 for launch configuration

```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
