### PR TITLE
update resource naming module version for terraform v0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,12 @@
 module "launch_template_name" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.18.1"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.19.1"
 
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "launch_configuration"
 }
 
 module "asg_name" {
-  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.18.1"
+  source = "github.com/traveloka/terraform-aws-resource-naming.git?ref=v0.19.1"
 
   name_prefix   = "${var.service_name}-${var.cluster_role}"
   resource_type = "autoscaling_group"

--- a/providers.tf
+++ b/providers.tf
@@ -1,3 +1,0 @@
-provider "random" {
-  version = ">= 1.2.0, < 3.0.0"
-}

--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,3 @@
+provider "random" {
+  version = ">= 1.2.0, < 3.0.0"
+}


### PR DESCRIPTION
Signed-off-by: Nur Adhi Nugroho <nur.nugroho@traveloka.com>

<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes #0000

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Update resource naming module version that support terraform v0.12

BUG FIXES:

* Prevent incompatibility when using terraform v0.12 stack
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
