### PR TITLE
Terraform Apply Error caused by Invalid launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,11 +39,11 @@ resource "aws_launch_template" "main" {
   }
 
   key_name               = "${var.key_name}"
-  vpc_security_group_ids = ["${var.security_groups}"]
   user_data              = "${base64encode(var.user_data)}"
 
   network_interfaces {
     associate_public_ip_address = "${var.associate_public_ip}"
+    security_groups = ["${var.security_groups}"]
   }
 
   monitoring {


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
## Summary
```
1 error occurred:
        * module.xxtnet-app.module.aws-autoscaling_app.aws_autoscaling_group.main: 1 error occurred:
        * aws_autoscaling_group.main: Error creating AutoScaling Group: InvalidQueryParameter: Invalid launch template: When a network interface is provided, the security groups must be a part of it.
```
Similar issue: https://github.com/traveloka/terraform-aws-autoscaling/issues/38

## Module Version
0.2.3

## Terraform Version and Terraform AWS Provider Version
Terraform 0.11.14
"aws" (2.70.0)

## Affected Resource(s)
aws_autoscaling_group

## Expected Behavior
terraform apply successfully

## Actual Behavior
```
1 error occurred:
        * module.xxtnet-app.module.aws-autoscaling_app.aws_autoscaling_group.main: 1 error occurred:
        * aws_autoscaling_group.main: Error creating AutoScaling Group: InvalidQueryParameter: Invalid launch template: When a network interface is provided, the security groups must be a part of it.
```
## Steps to Reproduce
- terraform apply

cc @traveloka/backend-axes 