### PR TITLE
[Terraform 0.11] Move security group to network interfaces in launch template

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,12 +38,14 @@ resource "aws_launch_template" "main" {
     cpu_credits = "${var.cpu_credits}"
   }
 
-  key_name               = "${var.key_name}"
-  vpc_security_group_ids = ["${var.security_groups}"]
-  user_data              = "${base64encode(var.user_data)}"
+  key_name  = "${var.key_name}"
+  user_data = "${base64encode(var.user_data)}"
 
   network_interfaces {
     associate_public_ip_address = "${var.associate_public_ip}"
+    security_groups             = ["${var.security_groups}"]
+    delete_on_termination       = "${var.eni_delete_on_termination}"
+    description                 = "${module.asg_name.name} ENI"
   }
 
   monitoring {
@@ -59,7 +61,7 @@ resource "aws_launch_template" "main" {
       volume_size           = "${var.volume_size}"
       volume_type           = "${var.volume_type}"
       delete_on_termination = "${var.delete_on_termination}"
-      encrypted            = "${var.ebs_encryption}"
+      encrypted             = "${var.ebs_encryption}"
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -220,6 +220,11 @@ variable "delete_on_termination" {
   default     = "true"
 }
 
+variable "eni_delete_on_termination" {
+  description = "Whether the network interface should be destroyed on instance termination"
+  default     = "true"
+}
+
 variable "ebs_encryption" {
   description = "Whether the volume will be encrypted or not"
   default     = "false"


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Fixes https://github.com/traveloka/terraform-aws-autoscaling/issues/38

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

BUG FIXES:

* Fix Error creating AutoScaling Group: InvalidQueryParameter: Invalid launch template: When a network interface is provided, the security groups must be a part of it.
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
