### PR TITLE
Add desired count for asg with autoscaling policy

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,5 @@
 locals {
   # Set the wait_for_elb_capacity to asg_min_capacity if not explicitly provided
   asg_wait_for_elb_capacity = "${var.asg_wait_for_elb_capacity == "" ? var.asg_min_capacity : var.asg_wait_for_elb_capacity}"
+  desired_capacity = "${var.asg_desired_capacity == "-1" ? var.asg_min_capacity : var.asg_desired_capacity}"
 }

--- a/main.tf
+++ b/main.tf
@@ -105,6 +105,7 @@ resource "aws_autoscaling_group" "main" {
   name_prefix               = "${module.asg_name.name}"
   max_size                  = "${var.asg_max_capacity}"
   min_size                  = "${var.asg_min_capacity}"
+  desired_capacity          = "${local.desired_capacity}"
   default_cooldown          = "${var.asg_default_cooldown}"
   health_check_grace_period = "${var.asg_health_check_grace_period}"
   health_check_type         = "${var.asg_health_check_type}"

--- a/variables.tf
+++ b/variables.tf
@@ -248,3 +248,8 @@ variable "mixed_instances_distribution" {
     spot_max_price                           = ""
   }
 }
+
+variable "asg_desired_capacity" {
+  description = "What is the current desired count that you want to have"
+  default     = "-1"  
+}


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
State an issue that you address on this PR.
--->
Add a layer so people can set the desired_count equal to that of the current asg instance count. (previously it always follow min_instance, this is bad because you might spin up a new asg that isn't powerful enough for the current traffic)

Desired count is validate between min and max asg count by terraform automatically
Example of the validation occurring
```

Error: Error applying plan:

1 error occurred:
        * module.canary_app_asg.aws_autoscaling_group.main: 1 error occurred:
        * aws_autoscaling_group.main: Error updating Autoscaling group: ValidationError: Desired capacity:10 must be between the specified min size:1 and max size:1
        status code: 400, request id: f9303606-a070-437a-b686-792df12b9189

Error: Error applying plan:

1 error occurred:
        * module.canary_app_asg.aws_autoscaling_group.main: 1 error occurred:
        * aws_autoscaling_group.main: Error updating Autoscaling group: ValidationError: Desired capacity:0 must be between the specified min size:1 and max size:1
        status code: 400, request id: 515a5522-0e08-4c26-8815-bd8d5e3729bc


```

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-autoscaling/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Add desired count as variable, defaults to min_capacity when unset

FEATURES:

* **New Source:** `aws_000_0000` ([#references_to_issue](./))

ENHANCEMENTS:

* feature: Add support for new version of AWS API

BUG FIXES:

* Prevent error from evil bugs
```

***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan

```

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
